### PR TITLE
Fix font loading bug and correct Reactive arithmetic methods

### DIFF
--- a/ezsgame/objects/text.py
+++ b/ezsgame/objects/text.py
@@ -94,15 +94,15 @@ class Text(Object):
         # if font is a path | str
         elif isinstance(self.font, str):
             # if font in system fonts
-            if font in pg.font.get_fonts():
+            if self.font in pg.font.get_fonts():
                 font = pg.font.SysFont(
-                    font, self.font_size.get(), self.bold, self.italic
+                    self.font, self.font_size.get(), self.bold, self.italic
                 )
 
             # if font is a path
-            elif font.endswith(".ttf"):
+            elif self.font.endswith(".ttf"):
                 try:
-                    font = pg.font.Font(font, self.font_size.get())
+                    font = pg.font.Font(self.font, self.font_size.get())
                 except Exception as e:
                     raise ValueError(f"Error loading font: {e}")
 

--- a/ezsgame/reactivity.py
+++ b/ezsgame/reactivity.py
@@ -60,14 +60,14 @@ class Reactive:
     def __sub__(self, other):
         return self._value - other
 
-    def __mult__(self, other):
+    def __mul__(self, other):
         return self._value * other
     
     def __div__(self, other):
         return self._value / other
     
     def __truediv__(self, other):
-        return self._value // other
+        return self._value / other
     
     def __pow__(self, other):
         return self._value ** other


### PR DESCRIPTION
## Summary
- fix references to `self.font` when loading fonts
- correct arithmetic methods in `Reactive`

## Testing
- `python -m compileall -q ezsgame`

------
https://chatgpt.com/codex/tasks/task_e_685b46b9de8c8321ac3be33a87281b80